### PR TITLE
add MCP server badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,10 @@
 
 Production-ready MCP server that provides LLMs with essential random generation abilities --- built entirely on Python's standard library.
 
+<a href="https://glama.ai/mcp/servers/@zazencodes/random-number-mcp">
+  <img width="380" height="200" src="https://glama.ai/mcp/servers/@zazencodes/random-number-mcp/badge" alt="Random Number MCP server" />
+</a>
+
 ## 🎲 Tools
 
 
@@ -21,7 +25,7 @@ Production-ready MCP server that provides LLMs with essential random generation 
 
 Add this to your Claude Desktop configuration file:
 
-**macOS**: `~/Library/Application Support/Claude/claude_desktop_config.json`
+**macOS**: `~/Library/Application Support/Claude/claude_desktop_config.json`  
 **Windows**: `%APPDATA%/Claude/claude_desktop_config.json`
 
 ```json


### PR DESCRIPTION
This PR adds a badge for the [Random Number MCP](https://glama.ai/mcp/servers/@zazencodes/random-number-mcp) server listing in Glama MCP server directory.

<a href="https://glama.ai/mcp/servers/@zazencodes/random-number-mcp">
  <img width="380" height="200" src="https://glama.ai/mcp/servers/@zazencodes/random-number-mcp/badge" alt="Random Number MCP server" />
</a>

Glama performs regular codebase and documentation checks to:

* Confirm that the MCP server is working as expected
* Confirm that there are no obvious security issues with dependencies of the server
* Extract server characteristics such as tools, resources, prompts, and required parameters.

This badge helps your users to quickly assess that the MCP server is safe, server capabilities, and instructions for installing the server.